### PR TITLE
Replace forked markdown-it-eleventy-img with upstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "markdown-it": "^14.0.0",
         "markdown-it-abbr": "^2.0.0",
         "markdown-it-anchor": "^8.6.5",
-        "markdown-it-eleventy-img": "https://github.com/madrilene/markdown-it-eleventy-img",
+        "markdown-it-eleventy-img": "^0.10.2",
         "markdown-it-emoji": "^3.0.0",
         "markdown-it-footnote": "^4.0.0",
         "markdown-it-link-attributes": "^4.0.1",
@@ -3989,15 +3989,16 @@
       }
     },
     "node_modules/markdown-it-eleventy-img": {
-      "version": "0.10.1",
-      "resolved": "git+ssh://git@github.com/madrilene/markdown-it-eleventy-img.git#f394a08ad3474e9a293dfa17f91338fe45010ee4",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/markdown-it-eleventy-img/-/markdown-it-eleventy-img-0.10.2.tgz",
+      "integrity": "sha512-/NAQtt+KKDugE2iWk8AahirM+KGm31INtkrlRXbzBFPnx1nFpyZBXchbluQSvwMbxYBCYkO4VuQAxMiIOkBOAA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@11ty/eleventy-img": "^4.0.2"
+        "@11ty/eleventy-img": "^4.0.2",
+        "sharp": "^0.33.2"
       },
       "engines": {
-        "node": ">=14.15"
+        "node": ">=18"
       },
       "peerDependencies": {
         "markdown-it": ">= 9.0.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "markdown-it": "^14.0.0",
     "markdown-it-abbr": "^2.0.0",
     "markdown-it-anchor": "^8.6.5",
-    "markdown-it-eleventy-img": "https://github.com/madrilene/markdown-it-eleventy-img",
+    "markdown-it-eleventy-img": "^0.10.2",
     "markdown-it-emoji": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-link-attributes": "^4.0.1",


### PR DESCRIPTION
upstream was updated.
rerun `npm install`